### PR TITLE
A fix for unsuccessful downloading of pretrained weights from Google Drive

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,13 +105,15 @@ In practice, the training of the knowledge alignment network is independent of t
 Therefore, steps 2 and 3 can be performed in parallel. 
 To achieve this, specify the path to the PyTorch state_dict of the VAE trained in step 1 by setting `vae.pretrained_ckpt_path` in the corresponding config files.  
 
-Find detailed instructions in how to train the models or running inference with our pretrained models in the corresponding script folder.
+Find detailed instructions in how to train the models or running inference with our pretrained models in the corresponding script folder. 
+The estimated training time is based on a single machine configured with 4 NVIDIA A10G GPUs.
+The actual training time may vary depending on your own hardware specifications.
 
-| Model Component             | Script Folder                          | Config                                                          |
-|-----------------------------|----------------------------------------|-----------------------------------------------------------------|
-| VAE                         | [scripts](./scripts/vae/sevirlr)       | [config](./scripts/vae/sevirlr/vae_sevirlr_v1.yaml)             |
-| Latent Earthformer-UNet     | [scripts](./scripts/prediff/sevirlr)   | [config](./scripts/prediff/sevirlr/prediff_sevirlr_v1.yaml)     |
-| Knowledge Alignment Network | [scripts](./scripts/alignment/sevirlr) | [config](./scripts/alignment/sevirlr/alignment_sevirlr_v1.yaml) |
+| Model Component             | Script Folder                          | Config                                                          | Estimated Time |
+|-----------------------------|----------------------------------------|-----------------------------------------------------------------|----------------|
+| VAE                         | [scripts](./scripts/vae/sevirlr)       | [config](./scripts/vae/sevirlr/vae_sevirlr_v1.yaml)             | 12 days        |
+| Latent Earthformer-UNet     | [scripts](./scripts/prediff/sevirlr)   | [config](./scripts/prediff/sevirlr/prediff_sevirlr_v1.yaml)     | 32 days        |
+| Knowledge Alignment Network | [scripts](./scripts/alignment/sevirlr) | [config](./scripts/alignment/sevirlr/alignment_sevirlr_v1.yaml) | 1 day          |
 
 ## Citing PreDiff
 

--- a/src/prediff/utils/download.py
+++ b/src/prediff/utils/download.py
@@ -18,7 +18,7 @@ pretrained_i3d_600_name = "pretrained_i3d_600.pt"
 # }
 file_id_dict = {
     pretrained_sevirlr_vae_name: "EZ-BfMnX-dhFrccXtLuCB78BPs3xBc-ke1BG4_9Jf7UblQ?e=bMplKs",
-    pretrained_sevirlr_earthformerunet_name: "EUp432GSXplCuhN7-WUF6YsBK4WrWiL8A9RZCA1Pf9D0Ag?e=kUSUb0",
+    pretrained_sevirlr_earthformerunet_name: "EUp432GSXplCuhN7-WUF6YsBK4WrWiL8A9RZCA1Pf9D0Ag?e=eY6hcQ",
     pretrained_sevirlr_alignment_name: "EWHH7y6w9D5Dg01YNX99IFQBA3tCR2a7s7z7Xv0BiNLV7Q?e=Hd9jCH",
     pretrained_i3d_400_name: "ESSxcaYvlrlAvXnsJoQ8P-kBusWJiM1D8pOu7wcNEVmzcw?e=HqWz8F",
     pretrained_i3d_600_name: "EU6tZPSExoZIgoAwu5hTkjoBBJu1RBFepjFsP68Msb6JFA?e=31aIfa",
@@ -51,4 +51,4 @@ def download_pretrained_weights(ckpt_name, save_dir=None, exist_ok=False):
         #           f" -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')"
         #           f"&id={file_id}\" -O {ckpt_path} && rm -rf /tmp/cookies.txt")
         os.system(f"wget https://hkustconnect-my.sharepoint.com/:u:/g/personal/zgaoag_connect_ust_hk/{file_id}"
-                  f"&download=1 -O {ckpt_path}")
+                  f"\&download=1 -O {ckpt_path}")

--- a/src/prediff/utils/download.py
+++ b/src/prediff/utils/download.py
@@ -9,12 +9,19 @@ pretrained_sevirlr_alignment_name = "pretrained_sevirlr_alignment_avg_x_cuboid_v
 pretrained_i3d_400_name = "pretrained_i3d_400.pt"
 pretrained_i3d_600_name = "pretrained_i3d_600.pt"
 
+# file_id_dict = {
+#     pretrained_sevirlr_vae_name: "10OicEQuOPzSKDp5WYF3zDHsL-COywe98",
+#     pretrained_sevirlr_earthformerunet_name: "1cVB0Sm2V4OMTLxNNEXlb2__ONqSAjUDJ",
+#     pretrained_sevirlr_alignment_name: "1CzrzNVDVTyc8ivnWqEOiJnrN6wraY6fy",
+#     pretrained_i3d_400_name: "1UwfpQEIi1jJqGmTmRWcIClEpXF3jKwOq",
+#     pretrained_i3d_600_name: "1wiueaTRfi0DqJUUaIF3l_ze8OMNF5NIQ",
+# }
 file_id_dict = {
-    pretrained_sevirlr_vae_name: "10OicEQuOPzSKDp5WYF3zDHsL-COywe98",
-    pretrained_sevirlr_earthformerunet_name: "1cVB0Sm2V4OMTLxNNEXlb2__ONqSAjUDJ",
-    pretrained_sevirlr_alignment_name: "1CzrzNVDVTyc8ivnWqEOiJnrN6wraY6fy",
-    pretrained_i3d_400_name: "1UwfpQEIi1jJqGmTmRWcIClEpXF3jKwOq",
-    pretrained_i3d_600_name: "1wiueaTRfi0DqJUUaIF3l_ze8OMNF5NIQ",
+    pretrained_sevirlr_vae_name: "EZ-BfMnX-dhFrccXtLuCB78BPs3xBc-ke1BG4_9Jf7UblQ?e=bMplKs",
+    pretrained_sevirlr_earthformerunet_name: "EUp432GSXplCuhN7-WUF6YsBK4WrWiL8A9RZCA1Pf9D0Ag?e=kUSUb0",
+    pretrained_sevirlr_alignment_name: "EWHH7y6w9D5Dg01YNX99IFQBA3tCR2a7s7z7Xv0BiNLV7Q?e=Hd9jCH",
+    pretrained_i3d_400_name: "ESSxcaYvlrlAvXnsJoQ8P-kBusWJiM1D8pOu7wcNEVmzcw?e=HqWz8F",
+    pretrained_i3d_600_name: "EU6tZPSExoZIgoAwu5hTkjoBBJu1RBFepjFsP68Msb6JFA?e=31aIfa",
 }
 
 
@@ -37,9 +44,11 @@ def download_pretrained_weights(ckpt_name, save_dir=None, exist_ok=False):
     else:
         os.makedirs(save_dir, exist_ok=True)
         file_id = file_id_dict[ckpt_name]
-        os.system(f"wget --load-cookies /tmp/cookies.txt "
-                  f"\"https://docs.google.com/uc?export=download&confirm="
-                  f"$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate "
-                  f"'https://docs.google.com/uc?export=download&id={file_id}'"
-                  f" -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')"
-                  f"&id={file_id}\" -O {ckpt_path} && rm -rf /tmp/cookies.txt")
+        # os.system(f"wget --load-cookies /tmp/cookies.txt "
+        #           f"\"https://docs.google.com/uc?export=download&confirm="
+        #           f"$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate "
+        #           f"'https://docs.google.com/uc?export=download&id={file_id}'"
+        #           f" -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')"
+        #           f"&id={file_id}\" -O {ckpt_path} && rm -rf /tmp/cookies.txt")
+        os.system(f"wget https://hkustconnect-my.sharepoint.com/:u:/g/personal/zgaoag_connect_ust_hk/{file_id}"
+                  f"&download=1 -O {ckpt_path}")


### PR DESCRIPTION
1. Fix the unsuccessful download of pretrained weights from Google Drive reported in #20 . The new implementation downloads from OneDrive.
2. Provide a report on the estimated training time costs.